### PR TITLE
Remove npm random package because it is outdated and anyway unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "node-dcom": "^1.0.9",
-    "random": "^2.1.1",
     "long": "^4.0.0"
   }
 }


### PR DESCRIPTION
The "random" npm package is listed as a dependency, but with an outdated version that by now even triggers npm audit warnings. The package isn't used anyway, so it should simply be removed from package.json.

Also, once this is done, please consider releasing the node-dcom library in the newest version (git repository has 1.0.10, but released is only 1.0.9).